### PR TITLE
fixes git+ssh dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/segmentio/validator/issues"
   },
   "dependencies": {
-    "each-component": "git+ssh://git@github.com:component/each#0.1.0",
+    "each-component": "git://github.com/component/each#0.1.0",
     "next-tick": "git://github.com/timoxley/next-tick#0.0.2",
     "ware": "~0.2.0"
   }


### PR DESCRIPTION
This commit allows us to install the dep from github without using
a public key.
